### PR TITLE
Fix base branch for update-inspektor-gadget-version

### DIFF
--- a/.github/workflows/update-inspektor-gadget-release.yaml
+++ b/.github/workflows/update-inspektor-gadget-release.yaml
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'docs: Add documentation for ${{ steps.bump_inspektor_gadget.outputs.version }}'
           branch: auto_bump_inspektor_gadget_version
-          base: master
+          base: main
           delete-branch: true
           title: 'docs: Add documentation for ${{ steps.bump_inspektor_gadget.outputs.version }}'
           body: |


### PR DESCRIPTION
The [workflow run failed ](https://github.com/inspektor-gadget/website/actions/runs/5455986848/jobs/9928167183)with an error message:

```
fatal: couldn't find remote ref master
Error: The process '/usr/bin/git' failed with exit code 128
```