### PR TITLE
Add artifacthub shortcode

### DIFF
--- a/themes/kinvolk-generic/layouts/shortcodes/artifacthub.html
+++ b/themes/kinvolk-generic/layouts/shortcodes/artifacthub.html
@@ -1,0 +1,1 @@
+<div class="artifacthub-widget-group" data-url="https://artifacthub.io/packages/search?repo=gadgets&sort=relevance&page=1" data-theme="light" data-header="false" data-stars="true" data-color="#417598" data-responsive="true"  data-loading="true"></div><script async src="https://artifacthub.io/artifacthub-widget.js"></script>


### PR DESCRIPTION
Following guide:
https://artifacthub.io/docs/topics/embedding_artifacts/

We can embed the gadgets we publish on the Artifact Hub.

This patch does not change the content of the website but merly allows the docs to use the following in the markdown: 
```
{{< artifacthub >}}
```

That could be used later in:
./external-docs/inspektor-gadget.git_mainlatest/docs/gadgets/_index.md

See https://github.com/inspektor-gadget/website/issues/42

## How to use

In the Inspektor Gadget main repository, we can have `docs/gadgets/_index.md` with the following content:
```
---
title: Gadgets
description: >
  This section provides guides for image-based gadgets.
weight: 35
---

{{< artifacthub >}}
```

## Testing done

```
make run
```

![image](https://github.com/inspektor-gadget/website/assets/27575/f132be91-dc97-4292-a74f-3ffb339f7752)

cc @blixtra @mayasingh17 @mauriciovasquezbernal 