### PR TITLE
Add redirects

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -24,6 +24,48 @@ const config: Config = {
   plugins: [
     "docusaurus-lunr-search",
     [
+      "@docusaurus/plugin-client-redirects",
+      {
+        redirects: [
+          {
+            from: "/docs",
+            to: "/docs/latest"
+          },
+          {
+            from: "/docs/latest/guides/run",
+            to: "/docs/latest/reference/run"
+          },
+          {
+            from: "/docs/latest/core-concepts/architecture",
+            to: "/docs/latest/reference/architecture"
+          },
+          {
+            from: "/docs/latest/getting-started/quick-start",
+            to: "/docs/latest/quick-start"
+          },
+          {
+            from: "/docs/latest/ig",
+            to: "/docs/latest/reference/ig"
+          },
+          {
+            from: "/docs/latest/getting-started/install-kubernetes",
+            to: "/docs/latest/reference/install-kubernetes"
+          },
+          {
+            from: "/docs/latest/getting-started/install-linux",
+            to: "/docs/latest/reference/install-linux"
+          },
+        ],
+        createRedirects(toPath) {
+          if (toPath.includes("/docs/latest/gadgets/builtin")) {
+            // Redirect to the new location of the builtin gadgets
+            return toPath.replace("/docs/latest/gadgets/builtin", "/docs/latest/builtin-gadgets");
+          }
+          return undefined;
+        }
+      },
+    ],
+    [
       "@docusaurus/plugin-ideal-image",
       {
         quality: 70,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "^3.4.0",
+        "@docusaurus/plugin-client-redirects": "^3.4.0",
         "@docusaurus/plugin-ideal-image": "^3.4.0",
         "@docusaurus/preset-classic": "^3.4.0",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
@@ -2509,6 +2510,29 @@
         "utility-types": "^3.10.0",
         "webpack": "^5.88.1",
         "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.4.0.tgz",
+      "integrity": "sha512-Pr8kyh/+OsmYCvdZhc60jy/FnrY6flD2TEAhl4rJxeVFxnvvRgEhoaIVX8q9MuJmaQoh6frPk94pjs7/6YgBDQ==",
+      "dependencies": {
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
       },
       "peerDependencies": {
         "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.4.0",
+    "@docusaurus/plugin-client-redirects": "^3.4.0",
     "@docusaurus/plugin-ideal-image": "^3.4.0",
     "@docusaurus/preset-classic": "^3.4.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",


### PR DESCRIPTION
It seems search engines are pointing to older links so it makes sense to add redirects. 

## How to test

```
$ npm run link-docs
$ npm run build # npm run start won't work since redirect plugin only work in production
$ npm run serve
```

Then if you open http://localhost:3000/docs/latest/builtin-gadgets/trace/open you will be redirected to http://localhost:3000/docs/latest/gadgets/builtin/trace/open

ref: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects
