### PR TITLE
Reorder same-day posts to highlight the big announcment

### DIFF
--- a/blog/2024-08-06-ig-in-mariner-3.md
+++ b/blog/2024-08-06-ig-in-mariner-3.md
@@ -6,6 +6,7 @@ tags: ["eBPF", "ig", "inspektor gadget", "Mariner", "AzureLinux"]
 title: "Inspektor Gadget is available in AzureLinux 3"
 slug: /2024/08/inspektor-gadget-is-available-in-azure-linux-3
 image: /media/ig-in-mariner-3.jpg
+date: 2024-08-06T10:00
 ---
 
 Last week, the team behind Azure Linux officially released its [version 3](https://github.com/microsoft/azurelinux/releases/tag/3.0.20240727-3.0).

--- a/blog/2024-08-06-ig-v0.31.0.md
+++ b/blog/2024-08-06-ig-v0.31.0.md
@@ -6,6 +6,7 @@ tags: ["eBPF", "bpf", "inspektor gadget", "gadget", "OCI"]
 title: "Empowering Observability: The Advent of Image-Based Gadgets"
 slug: /2024/08/empowering-observability_the_advent_of_image_based_gadgets
 image: /media/2024-08-06-header.jpeg
+date: 2024-08-06T11:00
 ---
 Today, with the release of [v0.31.0](https://github.com/inspektor-gadget/inspektor-gadget/releases/tag/v0.31.0), we announce the general availability of image-based Gadgets, the core building block of Inspektor Gadget’s newly defined data collection and systems inspection framework; enabling an ecosystem of observability tooling to be built with Inspektor Gadget.
 


### PR DESCRIPTION
We almost immediately deprioritized the major project update post on the blog section of the site by posting a feature highlight. This PR times the major announcement post to be after the feature update post so that it is highlighted on the blog section of the site.