### PR TITLE
deployment: Remove Content-Security-Policy header

### DIFF
--- a/static/staticwebapp.config.json
+++ b/static/staticwebapp.config.json
@@ -1,9 +1,8 @@
 {
-	"globalHeaders": {
-		"Content-Type": "text/html; charset=UTF-8",
-		"Content-Security-Policy": "script-src 'self'",
-		"Permissions-Policy": "geolocation=(), microphone=(), camera=()",
-		"X-Frame-Options": "SAMEORIGIN",
-		"X-Permitted-Cross-Domain-Policies": "none"
-	}
+  "globalHeaders": {
+    "Content-Type": "text/html; charset=UTF-8",
+    "Permissions-Policy": "geolocation=(), microphone=(), camera=()",
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-Permitted-Cross-Domain-Policies": "none"
+  }
 }


### PR DESCRIPTION
# Remove Content-Security-Policy header in azure deployment config

Some scripts are inlined or using eval for features like search or theme detection.
Content-Security-Policy header that is set in `static/staticwebapp.config.json:4` breaks those scripts
I'm pretty sure that the risks of a malicious code inject in a statically generated website are quite low, so I don't think that header is necessary

## Testing done

Can't test until it's deployed

Should fix #61 
