### PR TITLE
Implement remak plugin to replace version string in docs

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,6 +4,8 @@ import type * as Preset from "@docusaurus/preset-classic";
 import { githubA11yLight } from "./src/prismColorTheme";
 import versions from "./versions.json";
 
+import versionReplacer from './src/remark/version-replacer';
+
 const latestVersionName = versions[0];
 
 const config: Config = {
@@ -109,6 +111,7 @@ const config: Config = {
       "classic",
       {
         docs: {
+          remarkPlugins: [versionReplacer],
           lastVersion: "current",
           versions: {
             current: {

--- a/src/remark/version-replacer.js
+++ b/src/remark/version-replacer.js
@@ -1,0 +1,54 @@
+// This is a remark plugin that replaces the Inspetkor Gadget version in the
+// docs. It provides support for two constants:
+// - %IG_TAG% - This constant is intended to be used for container images. For
+//   releases it contains the version number with the "v" prefix. For the latest
+//   version it contains the "latest" string.
+// - %IG_BRANCH%' - This constant contains the tag of the name of the branch
+
+import { visit } from 'unist-util-visit';
+
+const tagConstant = '%IG_TAG%';
+const branchConstant = '%IG_BRANCH%';
+
+export default function versionReplacer() {
+  return (tree, vfile) => {
+    // Extract the version from the path of the file being built
+    const versionMatch = vfile.path.match(/version-v(\d+\.\d+\.\d+)/);
+    const version = versionMatch ? "v"+versionMatch[1] : null;
+
+    const tag = version ? version : 'latest';
+    const branch = version ? version : 'main';
+
+    // Traverse the MDX AST tree
+    visit(tree, (node) => {
+      // Handle regular text nodes
+      if (node.type === 'text') {
+        if (node.value.includes(tagConstant)) {
+          node.value = node.value.replace(new RegExp(tagConstant, 'g'), tag);
+        }
+        if (node.value.includes(branchConstant)) {
+          node.value = node.value.replace(new RegExp(branchConstant, 'g'), branch);
+        }
+      }
+
+      // Handle code block nodes
+      if (node.type === 'code' || node.type === 'inlineCode') {
+        if (node.value.includes(tagConstant)) {
+          node.value = node.value.replace(new RegExp(tagConstant, 'g'), tag);
+        }
+        if (node.value.includes(branchConstant)) {
+          node.value = node.value.replace(new RegExp(branchConstant, 'g'), branch);
+        }
+
+      // Handle links
+      } else if (node.type === 'link') {
+        if (node.url.includes(tagConstant)) {
+          node.url = node.url.replace(new RegExp(tagConstant, 'g'), tag);
+        }
+        if (node.url.includes(branchConstant)) {
+          node.url = node.url.replace(new RegExp(branchConstant, 'g'), branch);
+        }
+      }
+    });
+  };
+}


### PR DESCRIPTION
We provide documentation for few versions of
Inspektor Gadget. Before this commit we're always
using "latest" in all the documentation, it was a
bit misleading as the features of a component can
change from one version to the other.

This commit adds a remark plugin that replaces
some constants with the actual version of the
documentation.

See how it's used in https://github.com/inspektor-gadget/inspektor-gadget/pull/3496
