### PR TITLE
Point latest to latest release and introduce main version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,10 @@ params:
     - design
     external_docs:
     - repo: https://github.com/inspektor-gadget/inspektor-gadget.git
+      name: latest
+      branch: v0.40.0
+      dir: docs
+    - repo: https://github.com/inspektor-gadget/inspektor-gadget.git
       name: v0.40.0
       branch: v0.40.0
       dir: docs
@@ -17,6 +21,6 @@ params:
       branch: v0.38.1
       dir: docs
     - repo: https://github.com/inspektor-gadget/inspektor-gadget.git
-      name: latest
+      name: main
       branch: main
       dir: docs

--- a/tools/add-version.py
+++ b/tools/add-version.py
@@ -27,16 +27,34 @@ def add_version(config_file_path, version, max_versions):
         'dir': 'docs',
     }
 
+    new_version_latest = {
+        'repo': 'https://github.com/inspektor-gadget/inspektor-gadget.git',
+        'name': 'latest',
+        'branch': version,
+        'dir': 'docs',
+    }
+
     external_docs = config['params']['docs']['external_docs']
-    external_docs.insert(0, new_version)
+    new_external_docs = [new_version_latest, new_version]
 
-    size = len(external_docs)
-    if size > max_versions:
-        # Put latest at the before latest element and remove the latest element.
-        external_docs[size - 2] = external_docs[size - 1]
-        external_docs.pop()
+    count = 2
+    for docs in external_docs:
+        if count >= max_versions:
+            break
+        if docs['name'] == 'latest' or docs['name'] == 'main' or docs['name'] == version:
+            continue
+        new_external_docs.append(docs)
+        count += 1
 
-    config['params']['docs']['external_docs'] = external_docs
+    main_version = {
+        'repo': 'https://github.com/inspektor-gadget/inspektor-gadget.git',
+        'name': 'main',
+        'branch': 'main',
+        'dir': 'docs',
+    }
+
+    new_external_docs.append(main_version)
+    config['params']['docs']['external_docs'] = new_external_docs
 
     config_file = open(config_file_path, "w")
     config_file.write(yaml.dump(config, sort_keys=False))


### PR DESCRIPTION
This commit updates the atest tag to point to the latest release and introduces a new main tag pointing to the dev documents. This follows the same approach we use for container images.

