### PR TITLE
fix: validate version before creating PR to avoid 'null' titles

### DIFF
--- a/.github/workflows/update-inspektor-gadget-release.yaml
+++ b/.github/workflows/update-inspektor-gadget-release.yaml
@@ -20,9 +20,14 @@ jobs:
       - name: Bump inspektor-gadget version
         id: bump_inspektor_gadget
         run: |
-          inspektor_gadget_version=$(curl --silent https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest | jq .tag_name | tr -d '"')
+          inspektor_gadget_version=$(curl --silent https://api.github.com/repos/inspektor-gadget/inspektor-gadget/releases/latest | jq -r .tag_name)
 
-          if [ -z "$(grep $inspektor_gadget_version config.yaml)"]; then
+          if [ -z "$inspektor_gadget_version" ] || [ "$inspektor_gadget_version" = "null" ]; then
+            echo "Failed to fetch latest version"
+            exit 1
+          fi
+
+          if [ -z "$(grep "$inspektor_gadget_version" config.yaml)" ]; then
             python3 tools/add-version.py config.yaml $inspektor_gadget_version
           fi
 


### PR DESCRIPTION
When the GitHub API returns an error or is rate-limited, jq .tag_name outputs 'null', causing PRs with 'null' in the title (see #205, #207).

Changes:
- Use jq -r for raw output instead of piping through tr -d
- Add guard to fail early if version is empty or 'null'
- Fix missing space before ] in grep check
- Quote variable in grep to prevent word splitting

cc @mauriciovasquezbernal 